### PR TITLE
Update qso_end_date of existing certs where time is 00:00:00

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -21,7 +21,7 @@ $config['migration_enabled'] = TRUE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 124;
+$config['migration_version'] = 125;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/125_lotw_enddates.php
+++ b/application/migrations/125_lotw_enddates.php
@@ -1,0 +1,21 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_lotw_enddates extends CI_Migration
+{
+	public function up()
+	{
+		if ($this->db->table_exists('lotw_certs')) {
+			$sql = 'UPDATE lotw_certs SET qso_end_date = DATE_ADD(qso_end_date, INTERVAL 24*60*60 -1 SECOND) WHERE TIME(qso_end_date) = "00:00:00";';
+			$this->db->query($sql);
+		}
+	}
+
+	public function down()
+	{
+		if ($this->db->table_exists('lotw_certs')) {
+			$sql = 'UPDATE lotw_certs SET qso_end_date = DATE_SUB(qso_end_date, INTERVAL 24*60*60 -1 SECOND) WHERE TIME(qso_end_date) = "23:59:59";';
+			$this->db->query($sql);
+		}
+	}
+}


### PR DESCRIPTION
This adds a DB migration to upgrade existing certificates with time set to 00:00:00 in order to prevent the user from having to re-upload then.